### PR TITLE
refactor(frontend): modify i18n korean translatiion

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -260,7 +260,7 @@
     "en": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
     "zh-CN": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
     "de": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
-    "ko-KR": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
+    "ko-KR": "안녕하세요! 저는 오픈데빈(OpenDevin), AI 소프트웨어 엔지니어입니다. 오늘은 저와 함께 무엇을 만들어 볼까요?",
     "no": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
     "zh-TW": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
     "it": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
@@ -272,7 +272,7 @@
   "CHAT_INTERFACE$ASSISTANT": {
     "en": "Assistant",
     "zh-CN": "Assistant",
-    "ko-KR": "Assistant",
+    "ko-KR": "어시스턴트",
     "de": "Assistant",
     "no": "Assistant",
     "zh-TW": "Assistant",


### PR DESCRIPTION
Updated the Korean translation for the key "en" in the section where OpenDevin introduces itself, to make it more specific and localized. The previous text was a direct English transliteration, while the new text translates and adapts the message for Korean speakers.
Changed the translation for "Assistant" in Korean from the English word "Assistant" to the Korean word "어시스턴트", which is a transliteration of the English term into Korean script.